### PR TITLE
merge the latest development branch

### DIFF
--- a/uclcmd.c
+++ b/uclcmd.c
@@ -721,6 +721,8 @@ process_get_command(const ucl_object_t *obj, char *nodepath,
 	    fprintf(stderr, "DEBUG: Found 0 objects to each over\n");
 	}
     } else if (strcmp(command_str, "recurse") == 0) {
+	if (strlen(nodepath) > 0)
+	    output_chunk(obj, nodepath, "");
 	it = NULL;
 	while ((cur = ucl_iterate_object(obj, &it, true))) {
 	    char *newkey = NULL;
@@ -736,7 +738,6 @@ process_get_command(const ucl_object_t *obj, char *nodepath,
 	    if (ucl_object_type(cur) == UCL_OBJECT ||
 		    ucl_object_type(cur) == UCL_ARRAY) {
 		it2 = NULL;
-		output_chunk(cur, nodepath, newkey);
 		if (ucl_object_type(cur) == UCL_ARRAY) {
 		    ucl_object_t *arrlen = NULL;
 		    char *tmpkeyname;

--- a/uclcmd.c
+++ b/uclcmd.c
@@ -727,12 +727,15 @@ process_get_command(const ucl_object_t *obj, char *nodepath,
 	    if (obj->type == UCL_ARRAY) {
 		asprintf(&newkey, "%s%i", output_sepchar, arrindex);
 		arrindex++;
+	    } else if (strlen(nodepath) == 0) {
+		asprintf(&newkey, "%s", ucl_object_key(cur));
 	    } else {
 		asprintf(&newkey, "%s%s", output_sepchar, ucl_object_key(cur));
 	    }
 	    if (ucl_object_type(cur) == UCL_OBJECT ||
 		    ucl_object_type(cur) == UCL_ARRAY) {
 		it2 = NULL;
+		output_chunk(cur, nodepath, newkey);
 		if (ucl_object_type(cur) == UCL_ARRAY) {
 		    ucl_object_t *arrlen = NULL;
 		    char *tmpkeyname;
@@ -1327,7 +1330,7 @@ type_as_string (const ucl_object_t *obj)
 void
 ucl_obj_dump (const ucl_object_t *obj, unsigned int shift)
 {
-    int num = shift * 4 + 5;
+    int num = shift * 2 + 5;
     char *pre = (char *) malloc (num * sizeof(char));
     const ucl_object_t *cur, *tmp;
     ucl_object_iter_t it = NULL, it_obj = NULL;

--- a/uclcmd.c
+++ b/uclcmd.c
@@ -729,7 +729,7 @@ process_get_command(const ucl_object_t *obj, char *nodepath,
 	char *tmpkeyname = NULL;
 	if (strlen(nodepath) > 0) {
 	    output_chunk(obj, nodepath, "");
-	    if (ucl_object_type(obj) == UCL_ARRAY) {
+	    if (expand && ucl_object_type(obj) == UCL_ARRAY) {
 		    ucl_object_t *arrlen = NULL;
 
 		    arrlen = ucl_object_fromint(obj->len);
@@ -1042,7 +1042,7 @@ merge_mode(char *destination_node, char *data)
 	    fprintf(stderr, "Merging object %s with object %s\n",
 		ucl_object_key(sub_obj), ucl_object_key(set_obj));
 	}
-	/* not supported:
+	/* XXX not supported:
 	 * success = ucl_object_merge(sub_obj, set_obj, false, true);
 	 */
 	success = ucl_object_merge(sub_obj, set_obj, false);

--- a/uclcmd.c
+++ b/uclcmd.c
@@ -1198,7 +1198,7 @@ output_chunk(const ucl_object_t *obj, char *nodepath, const char *inkey)
 	if (nonewline) {
 	    fprintf(stderr, "WARN: UCL output cannot be 'nonewline'd\n");
 	}
-	if (show_keys == 1)
+	if (show_keys == 1 && strlen(key) > 0)
 	    printf("%s%s=", nodepath, key);
 	printf("%s", result);
 	free(result);
@@ -1214,7 +1214,7 @@ output_chunk(const ucl_object_t *obj, char *nodepath, const char *inkey)
 	    fprintf(stderr,
 		"WARN: non-compact JSON output cannot be 'nonewline'd\n");
 	}
-	if (show_keys == 1)
+	if (show_keys == 1 && strlen(key) > 0)
 	    printf("%s%s=", nodepath, key);
 	printf("%s", result);
 	free(result);
@@ -1226,7 +1226,7 @@ output_chunk(const ucl_object_t *obj, char *nodepath, const char *inkey)
 	break;
     case UCL_EMIT_JSON_COMPACT: /* Compact JSON */
 	result = ucl_object_emit(obj, output_type);
-	if (show_keys == 1)
+	if (show_keys == 1 && strlen(key) > 0)
 	    printf("%s%s=", nodepath, key);
 	printf("%s", result);
 	free(result);
@@ -1241,7 +1241,7 @@ output_chunk(const ucl_object_t *obj, char *nodepath, const char *inkey)
 	if (nonewline) {
 	    fprintf(stderr, "WARN: YAML output cannot be 'nonewline'd\n");
 	}
-	if (show_keys == 1)
+	if (show_keys == 1 && strlen(key) > 0)
 	    printf("%s%s=", nodepath, key);
 	printf("%s", result);
 	free(result);

--- a/uclcmd.c
+++ b/uclcmd.c
@@ -42,7 +42,7 @@
  * Does ucl_object_insert_key_common need to respect NO_IMPLICIT_ARRAY
  */
 
-static int show_keys = 0, show_raw = 0, nonewline = 0, mode = 0, debug = 0;
+static int debug = 0, expand = 0, mode = 0, nonewline = 0, show_keys = 0, show_raw = 0;
 static bool firstline = true;
 static int output_type = 254;
 static ucl_object_t *root_obj = NULL;
@@ -95,7 +95,8 @@ main(int argc, char *argv[])
 	{ "cjson",	no_argument,            &output_type,
 	    UCL_EMIT_JSON_COMPACT },
 	{ "debug",      optional_argument,      NULL,       	'd' },
-	{ "delimiter",  required_argument,      NULL,       	'e' },
+	{ "delimiter",  required_argument,      NULL,       	'D' },
+	{ "expand",	no_argument,		NULL,		'e' },
 	{ "file",       required_argument,      NULL,       	'f' },
 	{ "get",        no_argument,            &mode,      	0 },
 	{ "json",       no_argument,            &output_type,
@@ -114,7 +115,7 @@ main(int argc, char *argv[])
 	{ NULL,         0,                      NULL,       	0 }
     };
 
-    while ((ch = getopt_long(argc, argv, "cde:f:gi:jklmnqrsuy", longopts, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "cdD:ef:gi:jklmnqrsuy", longopts, NULL)) != -1) {
 	switch (ch) {
 	case 'c':
 	    output_type = UCL_EMIT_JSON_COMPACT;
@@ -126,10 +127,12 @@ main(int argc, char *argv[])
 		debug = 1;
 	    }
 	    break;
-	case 'e':
-	    /* XXX: TODO: We only want the first character, malloc problems? */
+	case 'D':
 	    input_sepchar = optarg[0];
 	    output_sepchar = optarg[0];
+	    break;
+	case 'e':
+	    expand = 1;
 	    break;
 	case 'f':
 	    filename = optarg;
@@ -286,15 +289,16 @@ void
 usage()
 {
     fprintf(stderr, "%s\n",
-"Usage: uclcmd [-cdjklmnqruy] [-f filename] --get variable\n"
-"       uclcmd [-cdjklmnqruy] [-f filename] --set variable UCL\n"
-"       uclcmd [-cdjklmnqruy] [-f filename] [-i filename] --merge variable\n"
-"       uclcmd [-cdjklmnqruy] [-f filename] --remove variable\n"
+"Usage: uclcmd [-cdejklmnqruy] [-d char] [-f filename] --get variable\n"
+"       uclcmd [-cdejklmnqruy] [-d char] [-f filename] --set variable UCL\n"
+"       uclcmd [-cdejklmnqruy] [-d char] [-f filename] [-i filename] --merge variable\n"
+"       uclcmd [-cdejklmnqruy] [-d char] [-f filename] --remove variable\n"
 "\n"
 "OPTIONS:\n"
 "       -c --cjson      output compacted JSON\n"
 "       -d --debug      enable verbose debugging output\n"
-"       -e --delimiter  character to use as element delimiter (default is .)\n"
+"       -D --delimiter  character to use as element delimiter (default is .)\n"
+"	-e --expand	Output the list of keys when encountering an object\n"
 "       -f --file       path to a file to read or write\n"
 "       -g --get        return the value of the indicated key\n"
 "       -i --input      use indicated file as additional input (for merging)\n"


### PR DESCRIPTION
* -e for expand (list subkeys of objects, length of arrays)
* -D arbitrary delimiter (use a character other than . (dot) to separate objects) [requires update to libucl]
* add the |dump command (shows internal representation of the parsed objects)
* add the |recurse command (dumps the entire object tree as key=value pairs)
* Multivalue - after doing |each or the like, you can specify multiple space separated keys


 