### PR TITLE
More Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Debugging on
 CFLAGS?=-g -O0
-CFLAGS+=-Wall $(INCLUDES)
+CFLAGS+=-Wall
 CFLAGS+=`pkg-config --cflags libucl`
 LIBS+=`pkg-config --libs libucl`
 PREFIX?=/usr/local

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 # Debugging on
-INCLUDES=-I/usr/include -I/usr/local/include
-LDFLAGS=-L/usr/lib -L/usr/local/lib
-CFLAGS?= -g -O0 -Wall
-CFLAGS+=$(INCLUDES)
+CFLAGS?=-g -O0
+CFLAGS+=-Wall $(INCLUDES)
+CFLAGS+=`pkg-config --cflags libucl`
+LIBS+=`pkg-config --libs libucl`
 PREFIX?=/usr/local
-LIBS= -lucl
 SRCS=uclcmd.c uclcmd_common.c uclcmd_get.c uclcmd_merge.c \
 	uclcmd_output.c uclcmd_parse.c uclcmd_remove.c uclcmd_set.c
 OBJS=$(SRCS:.c=.o)


### PR DESCRIPTION
Followup to #14:

- -Wall can be always appended to CFLAGS
- Don't hardcode include and library paths: /usr/{include,lib} is not needed at all, and /usr/local/{include,lib} (paths to libucl) may be taken from pkg-config